### PR TITLE
Update presentation with different ways to create SipAssembler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.0.5
+version = 1.0.6
 
 
 # tag::sipSdkVersion[]

--- a/presentation/java/com/opentext/ia/sdk/presentation/MyFirstSips.java
+++ b/presentation/java/com/opentext/ia/sdk/presentation/MyFirstSips.java
@@ -9,13 +9,17 @@ import java.net.URI;
 import java.util.Map;
 
 import com.opentext.ia.sdk.sip.BatchSipAssembler;
+import com.opentext.ia.sdk.sip.ContentAssembler;
 import com.opentext.ia.sdk.sip.ContentInfo;
+import com.opentext.ia.sdk.sip.DefaultPackagingInformationFactory;
 import com.opentext.ia.sdk.sip.PackagingInformation;
 import com.opentext.ia.sdk.sip.PdiAssembler;
 import com.opentext.ia.sdk.sip.SipAssembler;
 import com.opentext.ia.sdk.sip.SipSegmentationStrategy;
 import com.opentext.ia.sdk.sip.XmlPdiAssembler;
-
+import com.opentext.ia.sdk.support.io.DataBufferSupplier;
+import com.opentext.ia.sdk.support.io.FileBuffer;
+import com.opentext.ia.sdk.support.io.NoHashAssembler;
 
 public final class MyFirstSips {
 
@@ -48,7 +52,7 @@ public final class MyFirstSips {
     // end::conversion[]
 
     // tag::generate[]
-    SipAssembler<Person> sipAssembler = SipAssembler.forPdi(prototype, pdiAssembler);
+    SipAssembler<Person> sipAssembler = getSipAssemblerWithInMemoryBuffering(prototype, pdiAssembler);
     SipSegmentationStrategy<Person> segmentationStrategy = SipSegmentationStrategy.byMaxAius(10);
     BatchSipAssembler<Person> batchAssembler = new BatchSipAssembler<>(sipAssembler,
         segmentationStrategy, new File("."));
@@ -58,6 +62,22 @@ public final class MyFirstSips {
     }
     batchAssembler.end();
     // end::generate[]
+  }
+
+  private static SipAssembler<Person> getSipAssemblerWithInMemoryBuffering(PackagingInformation prototype,
+      PdiAssembler<Person> pdiAssembler) {
+    // tag::inMemoryBuffer[]
+    return SipAssembler.forPdi(prototype, pdiAssembler);
+    // end::inMemoryBuffer[]
+  }
+
+  private SipAssembler<Person> getSipAssemblerWithFileBuffering(PackagingInformation prototype,
+      PdiAssembler<Person> pdiAssembler) {
+    // tag::fileBuffer[]
+    return new SipAssembler<>(new DefaultPackagingInformationFactory(prototype),
+        pdiAssembler, new NoHashAssembler(), new DataBufferSupplier<>(
+        FileBuffer.class), ContentAssembler.ignoreContent());
+    // end::fileBuffer[]
   }
 
   private static Person newPerson(int i) {

--- a/src/docs/asciidoc/presentation.adoc
+++ b/src/docs/asciidoc/presentation.adoc
@@ -217,9 +217,23 @@ the encoded hash value. The encoded hashes are made available to the `PdiAssembl
 <<<
 
 == Batch Generation of SIPs
+The example is below:
 [source,java,indent=0]
 ----
 include::{sourcedir}/presentation/java/com/opentext/ia/sdk/presentation/MyFirstSips.java[tags=generate]
+----
+Method 'SipAssembler.forPdi' convenient to use in case of small amount of AIUs, because it uses in-memory buffer
+for preserving them.
+[source,java,indent=0]
+----
+include::{sourcedir}/presentation/java/com/opentext/ia/sdk/presentation/MyFirstSips.java[tags=inMemoryBuffer]
+----
+If there are huge amount of AIUs with the method, then depending on the memory
+allocated for JVM, it is a risk to meet OutOfMemory exception.
+In this case, in order to create a PDI with huge amount of AIUs, it is required to use below:
+[source,java,indent=0]
+----
+include::{sourcedir}/presentation/java/com/opentext/ia/sdk/presentation/MyFirstSips.java[tags=fileBuffer]
 ----
 
 == Default Batch Segmentation Strategies


### PR DESCRIPTION
There was another one issue 
(https://github.com/Enterprise-Content-Management/infoarchive-sip-sdk/issues/51)  with regards how to create big SIP avoiding OOM exception. 
We decided to update the docs.  